### PR TITLE
Split out payload field JSON construction from encryption/decryption.…

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -138,7 +138,6 @@ interface Session {
                     url: String,
                     statusHandler: (Status) -> Unit,
                     messageHandler: (Message) -> Unit,
-                    sendHandler: (Message) -> Unit = {}
             ): Transport
         }
 

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -74,7 +74,7 @@ interface Session {
     }
 
     interface MessageLogger {
-        fun onMessage(message: Session.Transport.Message)
+        fun onMessage(message: Session.Transport.Message, isOwnMessage: Boolean)
     }
 
     interface Callback {

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -73,6 +73,10 @@ interface Session {
         }
     }
 
+    interface MessageLogger {
+        fun onMessage(message: Session.Transport.Message)
+    }
+
     interface Callback {
         fun onStatus(status: Status)
         fun onMethodCall(call: MethodCall)
@@ -90,9 +94,21 @@ interface Session {
     data class TransportError(override val cause: Throwable) : RuntimeException("Transport exception caused by $cause", cause)
 
     interface PayloadAdapter {
-        fun parse(payload: String, key: String): MethodCall
-        fun prepare(data: MethodCall, key: String): String
+        /**
+         * Takes in the decrypted payload JSON and returns the parsed [MethodCall].
+         */
+        fun parse(decryptedPayload: String): MethodCall
 
+        /**
+         * Takes in a [MethodCall] and returns the unencrypted payload JSON.
+         */
+        fun prepare(data: MethodCall): String
+
+    }
+
+    interface PayloadEncryption {
+        fun encrypt(unencryptedPayloadJson: String, key: String): String
+        fun decrypt(encryptedPayloadJson: String, key: String): String
     }
 
     interface Transport {
@@ -121,7 +137,8 @@ interface Session {
             fun build(
                     url: String,
                     statusHandler: (Status) -> Unit,
-                    messageHandler: (Message) -> Unit
+                    messageHandler: (Message) -> Unit,
+                    sendHandler: (Message) -> Unit = {}
             ): Transport
         }
 

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -74,7 +74,7 @@ interface Session {
     }
 
     interface MessageLogger {
-        fun onMessage(message: Session.Transport.Message, isOwnMessage: Boolean)
+        fun log(message: Session.Transport.Message, isOwnMessage: Boolean)
     }
 
     interface Callback {

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadEncryption.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadEncryption.kt
@@ -1,0 +1,82 @@
+package org.walletconnect.impls
+
+import com.squareup.moshi.Moshi
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.engines.AESEngine
+import org.bouncycastle.crypto.macs.HMac
+import org.bouncycastle.crypto.modes.CBCBlockCipher
+import org.bouncycastle.crypto.paddings.PKCS7Padding
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher
+import org.bouncycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.params.ParametersWithIV
+import org.komputing.khex.decode
+import org.komputing.khex.extensions.toNoPrefixHexString
+import org.walletconnect.Session
+import java.security.SecureRandom
+
+class MoshiPayloadEncryption(moshi: Moshi) : Session.PayloadEncryption {
+
+    private val payloadAdapter = moshi.adapter(MoshiPayloadAdapter.EncryptedPayload::class.java)
+
+    override fun encrypt(unencryptedPayloadJson: String, key: String): String {
+        val bytesData = unencryptedPayloadJson.toByteArray()
+        val hexKey = decode(key)
+        val iv = createRandomBytes(16)
+
+        val padding = PKCS7Padding()
+        val aes = PaddedBufferedBlockCipher(
+            CBCBlockCipher(AESEngine()),
+            padding
+        )
+        aes.init(true, ParametersWithIV(KeyParameter(hexKey), iv))
+
+        val minSize = aes.getOutputSize(bytesData.size)
+        val outBuf = ByteArray(minSize)
+        val length1 = aes.processBytes(bytesData, 0, bytesData.size, outBuf, 0)
+        aes.doFinal(outBuf, length1)
+
+
+        val hmac = HMac(SHA256Digest())
+        hmac.init(KeyParameter(hexKey))
+
+        val hmacResult = ByteArray(hmac.macSize)
+        hmac.update(outBuf, 0, outBuf.size)
+        hmac.update(iv, 0, iv.size)
+        hmac.doFinal(hmacResult, 0)
+
+        return payloadAdapter.toJson(
+            MoshiPayloadAdapter.EncryptedPayload(
+                outBuf.toNoPrefixHexString(),
+                hmac = hmacResult.toNoPrefixHexString(),
+                iv = iv.toNoPrefixHexString()
+            )
+        )
+    }
+
+    override fun decrypt(encryptedPayloadJson: String, key: String): String {
+        val encryptedPayload = payloadAdapter.fromJson(encryptedPayloadJson) ?: throw IllegalArgumentException("Invalid json payload!")
+
+        // TODO verify hmac
+
+        val padding = PKCS7Padding()
+        val aes = PaddedBufferedBlockCipher(
+            CBCBlockCipher(AESEngine()),
+            padding
+        )
+        val ivAndKey = ParametersWithIV(
+            KeyParameter(decode(key)),
+            decode(encryptedPayload.iv)
+        )
+        aes.init(false, ivAndKey)
+
+        val encryptedData = decode(encryptedPayload.data)
+        val minSize = aes.getOutputSize(encryptedData.size)
+        val outBuf = ByteArray(minSize)
+        var len = aes.processBytes(encryptedData, 0, encryptedData.size, outBuf, 0)
+        len += aes.doFinal(outBuf, len)
+
+        return String(outBuf.copyOf(len))
+    }
+
+    private fun createRandomBytes(i: Int) = ByteArray(i).also { SecureRandom().nextBytes(it) }
+}

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadEncryption.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadEncryption.kt
@@ -16,7 +16,7 @@ import java.security.SecureRandom
 
 class MoshiPayloadEncryption(moshi: Moshi) : Session.PayloadEncryption {
 
-    private val payloadAdapter = moshi.adapter(MoshiPayloadAdapter.EncryptedPayload::class.java)
+    private val encryptedPayloadAdapter = moshi.adapter(MoshiPayloadAdapter.EncryptedPayload::class.java)
 
     override fun encrypt(unencryptedPayloadJson: String, key: String): String {
         val bytesData = unencryptedPayloadJson.toByteArray()
@@ -44,7 +44,7 @@ class MoshiPayloadEncryption(moshi: Moshi) : Session.PayloadEncryption {
         hmac.update(iv, 0, iv.size)
         hmac.doFinal(hmacResult, 0)
 
-        return payloadAdapter.toJson(
+        return encryptedPayloadAdapter.toJson(
             MoshiPayloadAdapter.EncryptedPayload(
                 outBuf.toNoPrefixHexString(),
                 hmac = hmacResult.toNoPrefixHexString(),
@@ -54,7 +54,7 @@ class MoshiPayloadEncryption(moshi: Moshi) : Session.PayloadEncryption {
     }
 
     override fun decrypt(encryptedPayloadJson: String, key: String): String {
-        val encryptedPayload = payloadAdapter.fromJson(encryptedPayloadJson) ?: throw IllegalArgumentException("Invalid json payload!")
+        val encryptedPayload = encryptedPayloadAdapter.fromJson(encryptedPayloadJson) ?: throw IllegalArgumentException("Invalid json payload!")
 
         // TODO verify hmac
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
@@ -14,6 +14,7 @@ class OkHttpTransport(
     private val serverUrl: String,
     private val statusHandler: (Session.Transport.Status) -> Unit,
     private val messageHandler: (Session.Transport.Message) -> Unit,
+    private val sendHandler: (Session.Transport.Message) -> Unit,
     moshi: Moshi
 ) : Session.Transport, WebSocketListener() {
 
@@ -55,6 +56,7 @@ class OkHttpTransport(
                 queue.poll()?.let {
                     tryExec {
                         s.send(adapter.toJson(it.toMap()))
+                        sendHandler(it)
                     }
                     drainQueue() // continue draining until there are no more messages
                 }
@@ -121,14 +123,15 @@ class OkHttpTransport(
         }
     }
 
-    class Builder(val client: OkHttpClient, val moshi: Moshi) :
+    class Builder(private val client: OkHttpClient, private val moshi: Moshi) :
         Session.Transport.Builder {
         override fun build(
             url: String,
             statusHandler: (Session.Transport.Status) -> Unit,
-            messageHandler: (Session.Transport.Message) -> Unit
+            messageHandler: (Session.Transport.Message) -> Unit,
+            sendHandler: (Session.Transport.Message) -> Unit,
         ): Session.Transport =
-            OkHttpTransport(client, url, statusHandler, messageHandler, moshi)
+            OkHttpTransport(client, url, statusHandler, messageHandler, sendHandler, moshi)
 
     }
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
@@ -14,7 +14,6 @@ class OkHttpTransport(
     private val serverUrl: String,
     private val statusHandler: (Session.Transport.Status) -> Unit,
     private val messageHandler: (Session.Transport.Message) -> Unit,
-    private val sendHandler: (Session.Transport.Message) -> Unit,
     moshi: Moshi
 ) : Session.Transport, WebSocketListener() {
 
@@ -56,7 +55,6 @@ class OkHttpTransport(
                 queue.poll()?.let {
                     tryExec {
                         s.send(adapter.toJson(it.toMap()))
-                        sendHandler(it)
                     }
                     drainQueue() // continue draining until there are no more messages
                 }
@@ -129,9 +127,8 @@ class OkHttpTransport(
             url: String,
             statusHandler: (Session.Transport.Status) -> Unit,
             messageHandler: (Session.Transport.Message) -> Unit,
-            sendHandler: (Session.Transport.Message) -> Unit,
         ): Session.Transport =
-            OkHttpTransport(client, url, statusHandler, messageHandler, sendHandler, moshi)
+            OkHttpTransport(client, url, statusHandler, messageHandler, moshi)
 
     }
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -97,7 +97,7 @@ class WCSession(
                 config.handshakeTopic, "sub", ""
             )
             transport.send(message)
-            messageLogger.onMessage(message, isOwnMessage = true)
+            messageLogger.log(message, isOwnMessage = true)
         }
     }
 
@@ -173,7 +173,7 @@ class WCSession(
                     clientData.id, "sub", ""
                 )
                 transport.send(message)
-                messageLogger.onMessage(message, isOwnMessage = true)
+                messageLogger.log(message, isOwnMessage = true)
             }
             Session.Transport.Status.Disconnected -> {
                 // no-op
@@ -198,7 +198,7 @@ class WCSession(
             try {
                 val decryptedPayload = payloadEncryption.decrypt(message.payload, decryptionKey)
                 data = payloadAdapter.parse(decryptedPayload)
-                messageLogger.onMessage(message.copy(payload = decryptedPayload), isOwnMessage = false)
+                messageLogger.log(message.copy(payload = decryptedPayload), isOwnMessage = false)
             } catch (e: Exception) {
                 handlePayloadError(e)
                 return
@@ -299,7 +299,7 @@ class WCSession(
         }
         val message = Session.Transport.Message(topic, "pub", payload)
         transport.send(message)
-        messageLogger.onMessage(message.copy(payload = unencryptedPayload), isOwnMessage = true)
+        messageLogger.log(message.copy(payload = unencryptedPayload), isOwnMessage = true)
         return true
     }
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -93,11 +93,11 @@ class WCSession(
     override fun init() {
         if (transport.connect()) {
             // Register for all messages for this client
-            transport.send(
-                    Session.Transport.Message(
-                            config.handshakeTopic, "sub", ""
-                    )
+            val message = Session.Transport.Message(
+                config.handshakeTopic, "sub", ""
             )
+            transport.send(message)
+            messageLogger.onMessage(message, isOwnMessage = true)
         }
     }
 
@@ -169,11 +169,11 @@ class WCSession(
         when (status) {
             Session.Transport.Status.Connected -> {
                 // Register for all messages for this client
-                transport.send(
-                    Session.Transport.Message(
-                        clientData.id, "sub", ""
-                    )
+                val message = Session.Transport.Message(
+                    clientData.id, "sub", ""
                 )
+                transport.send(message)
+                messageLogger.onMessage(message, isOwnMessage = true)
             }
             Session.Transport.Status.Disconnected -> {
                 // no-op
@@ -198,7 +198,7 @@ class WCSession(
             try {
                 val decryptedPayload = payloadEncryption.decrypt(message.payload, decryptionKey)
                 data = payloadAdapter.parse(decryptedPayload)
-                messageLogger.onMessage(message.copy(payload = decryptedPayload))
+                messageLogger.onMessage(message.copy(payload = decryptedPayload), isOwnMessage = false)
             } catch (e: Exception) {
                 handlePayloadError(e)
                 return
@@ -299,7 +299,7 @@ class WCSession(
         }
         val message = Session.Transport.Message(topic, "pub", payload)
         transport.send(message)
-        messageLogger.onMessage(message.copy(payload = unencryptedPayload))
+        messageLogger.onMessage(message.copy(payload = unencryptedPayload), isOwnMessage = true)
         return true
     }
 


### PR DESCRIPTION
… Also introduce MessageLogger interface that logs messages with unencrypted payloads.

`PayloadAdapter` was doing too much work - it was both serializing/deserializing `MethodCall` into JSON as well as encrypting/decrypting that JSON. This PR splits out a new `PayloadEncryption` type responsible for the latter. This lets us easily log the unencrypted messages from within `WCSession`.

Logging unencrypted messages is fine - this isn't data we don't already have access to, and the encryption's main purpose is to prevent tampering by the bridge.