### PR TITLE
Switch to bc jdk15on dependency to be compatible with WCv2 library.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     implementation "com.github.komputing:khex:1.1.0"
 
-    implementation "org.bouncycastle:bcprov-jdk15to18:1.71"
+    implementation "org.bouncycastle:bcprov-jdk15on:1.70"
 
     implementation "com.squareup.moshi:moshi:$versions.moshi"
     ksp "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi"


### PR DESCRIPTION
The new WalletConnectV2 library uses `jdk15on` instead of `jdk15to18`, which causes duplicate class errors when using both the V2 library and this V1 library together in the same project.

The easiest path forward here is to switch this repo to use `jdk15on` so that Gradle can resolve any dependency conflicts easier.